### PR TITLE
Added check icon to active button states

### DIFF
--- a/src/components/SideNav.jsx
+++ b/src/components/SideNav.jsx
@@ -1,4 +1,5 @@
 import "/src/styles/side-nav.css";
+import { FaCheck } from "react-icons/fa";
 
 export default function SideNav({
   filterParams,
@@ -38,6 +39,7 @@ export default function SideNav({
                 aria-pressed={filterParams === "Easy"}
               >
                 Easy
+                {filterParams === "Easy" && <FaCheck aria-hidden="true" />}
               </button>
               <button
                 className={
@@ -47,6 +49,7 @@ export default function SideNav({
                 aria-pressed={filterParams === "Moderate"}
               >
                 Moderate
+                {filterParams === "Moderate" && <FaCheck aria-hidden="true" />}
               </button>
               <button
                 className={
@@ -56,6 +59,7 @@ export default function SideNav({
                 aria-pressed={filterParams === "Hard"}
               >
                 Hard
+                {filterParams === "Hard" && <FaCheck aria-hidden="true" />}
               </button>
               <button
                 className={
@@ -65,6 +69,7 @@ export default function SideNav({
                 aria-pressed={filterParams === "Stretch"}
               >
                 Stretch
+                {filterParams === "Stretch" && <FaCheck aria-hidden="true" />}
               </button>
             </div>
             <div className="clear-filter-sect">
@@ -91,6 +96,7 @@ export default function SideNav({
               onClick={() => updateTheme("theme-a")}
             >
               Blush
+              {theme === "theme-a" && <FaCheck aria-hidden="true" />}
             </button>
             <button
               role="radio"
@@ -99,6 +105,7 @@ export default function SideNav({
               onClick={() => updateTheme("theme-b")}
             >
               Aqua
+              {theme === "theme-b" && <FaCheck aria-hidden="true" />}
             </button>
             <button
               role="radio"
@@ -107,6 +114,7 @@ export default function SideNav({
               onClick={() => updateTheme("theme-c")}
             >
               Evergreen
+              {theme === "theme-c" && <FaCheck aria-hidden="true" />}
             </button>
             <button
               role="radio"
@@ -115,6 +123,7 @@ export default function SideNav({
               onClick={() => updateTheme("theme-d")}
             >
               Orange
+              {theme === "theme-d" && <FaCheck aria-hidden="true" />}
             </button>
           </div>
         </div>

--- a/src/styles/side-nav.css
+++ b/src/styles/side-nav.css
@@ -83,6 +83,10 @@
   font-family: "Noto Sans", serif;
   padding: 0.5em;
   margin: 0.5em 0.5em;
+  display: inline-flex;
+  gap: 5px;
+  align-items: center;
+  justify-content: center;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
Updated the active styling of filter and theme buttons to include a check icon, ensuring the selected state is not conveyed by colour alone (WCAG 1.4.1).
<img width="1148" height="705" alt="Screenshot 2026-04-01 at 14 57 49" src="https://github.com/user-attachments/assets/f5ec14bd-a752-420c-b206-6e34a223c89c" />
<img width="1308" height="715" alt="Screenshot 2026-04-01 at 14 58 14" src="https://github.com/user-attachments/assets/6d44eb11-c60d-457b-ad09-814212ea3d7e" />


